### PR TITLE
Remove hardcoded directory for some footprints

### DIFF
--- a/.github/workflows/kicad-footprints.yaml
+++ b/.github/workflows/kicad-footprints.yaml
@@ -6,11 +6,11 @@ jobs:
     name: kicad-footprints
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python 3.6
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.6
+        python-version: '3.6'
     - name: Init tools
       run: |
         make tools

--- a/.github/workflows/kicad-symbols.yaml
+++ b/.github/workflows/kicad-symbols.yaml
@@ -6,11 +6,11 @@ jobs:
     name: kicad-symbols
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python 3.6
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.6
+        python-version: '3.6'
     - name: Init tools
       run: |
         make tools

--- a/kicad-footprints/kbd.pretty/YS-SK6812MINI-E.kicad_mod
+++ b/kicad-footprints/kbd.pretty/YS-SK6812MINI-E.kicad_mod
@@ -37,7 +37,7 @@
   (pad "2" smd rect (at 2.8 0.7) (size 1.7 0.825) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp 942f848b-0c8d-4db1-b76f-5a52fab02801))
   (pad "3" smd rect (at -2.8 0.7) (size 1.7 0.825) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp a1c56f25-35f6-45b6-9a3c-b0ea3d32422f))
   (pad "4" smd rect (at -2.8 -0.7) (size 1.7 0.825) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp d01e975a-7550-40b5-96af-03cbb2d3d70b))
-  (model "/Users/foostan/go/src/github.com/foostan/kbd/kicad-packages3D/kbd.3dshapes/ys-sk6812mini-e.step"
+  (model "${KIPRJMOD}/kbd/kicad-packages3D/kbd.3dshapes/ys-sk6812mini-e.step"
     (offset (xyz 0 0 0.15))
     (scale (xyz 1 1 1))
     (rotate (xyz 180 0 180))

--- a/kicad-footprints/kbd.pretty/keyswitch_cherrymx_hotswap_1.5u.kicad_mod
+++ b/kicad-footprints/kbd.pretty/keyswitch_cherrymx_hotswap_1.5u.kicad_mod
@@ -84,7 +84,7 @@
   (pad "" np_thru_hole circle (at 5.08 0) (size 1.9 1.9) (drill 1.9) (layers "*.Cu" "*.Mask") (tstamp debcffcc-2e77-4306-a193-25bf2e688275))
   (pad "1" smd rect (at 7.085 -2.54 180) (size 2.55 2.5) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp a28031be-cb1a-4a9e-a321-22e0a056a425))
   (pad "2" smd rect (at -5.842 -5.08 180) (size 2.55 2.5) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp c288c31d-aa7b-4528-ba41-2e1475f105b1))
-  (model "/Users/foostan/go/src/github.com/foostan/kbd/kicad-packages3D/kbd.3dshapes/kailh_hotswap_socket.step"
+  (model "${KIPRJMOD}/kbd/kicad-packages3D/kbd.3dshapes/kailh_hotswap_socket.step"
     (offset (xyz 1.3 7.6 1.6))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 180 180))

--- a/kicad-footprints/kbd.pretty/keyswitch_cherrymx_hotswap_1u.kicad_mod
+++ b/kicad-footprints/kbd.pretty/keyswitch_cherrymx_hotswap_1u.kicad_mod
@@ -84,7 +84,7 @@
   (pad "" np_thru_hole circle (at 5.08 0) (size 1.9 1.9) (drill 1.9) (layers "*.Cu" "*.Mask") (tstamp debcffcc-2e77-4306-a193-25bf2e688275))
   (pad "1" smd rect (at 7.085 -2.54 180) (size 2.55 2.5) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp a28031be-cb1a-4a9e-a321-22e0a056a425))
   (pad "2" smd rect (at -5.842 -5.08 180) (size 2.55 2.5) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp c288c31d-aa7b-4528-ba41-2e1475f105b1))
-  (model "/Users/foostan/go/src/github.com/foostan/kbd/kicad-packages3D/kbd.3dshapes/kailh_hotswap_socket.step"
+  (model "${KIPRJMOD}/kbd/kicad-packages3D/kbd.3dshapes/kailh_hotswap_socket.step"
     (offset (xyz 1.3 7.6 1.6))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 180 180))

--- a/kicad-footprints/kbd.pretty/keyswitch_cherrymx_hotswap_1u_rotary_encoder_ec12.kicad_mod
+++ b/kicad-footprints/kbd.pretty/keyswitch_cherrymx_hotswap_1u_rotary_encoder_ec12.kicad_mod
@@ -99,7 +99,7 @@
   (pad "S1" thru_hole circle (at -2.5 -7.6) (size 1.2 1.2) (drill oval 1 0.5) (layers "*.Cu" "F.Mask") (tstamp 472de830-a7e9-4c3b-9f77-421404c0a788))
   (pad "S2" thru_hole circle (at 2.5 -7.6) (size 1.2 1.2) (drill oval 1 0.5) (layers "*.Cu" "F.Mask") (tstamp 9377934d-ee22-412b-95e5-13afb5db90eb))
   (pad "S2" smd rect (at 7 -2.54 180) (size 2.55 2) (layers "F.Cu" "F.Paste" "F.Mask") (tstamp a28031be-cb1a-4a9e-a321-22e0a056a425))
-  (model "/Users/foostan/go/src/github.com/foostan/kbd/kicad-packages3D/kbd.3dshapes/kailh_hotswap_socket.step"
+  (model "${KIPRJMOD}/kicad-packages3D/kbd.3dshapes/kailh_hotswap_socket.step"
     (offset (xyz 1.3 7.6 1.6))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 180 180))


### PR DESCRIPTION
Hey I've been playing around with modifying your corne v4 and run into some missing file issues. It seems to be that some of the parts here are using a dynamic path variable (and those work). But some paths are hardcoded to your local machine. See below:

This part works: 
https://github.com/foostan/kbd/blob/930e7d9467eecf03343c57f69bb4069a33f20846/kicad-footprints/kbd.pretty/LED_WS2812B-PLCC4.kicad_mod#L28

But this doesn't:
https://github.com/foostan/kbd/blob/930e7d9467eecf03343c57f69bb4069a33f20846/kicad-footprints/kbd.pretty/keyswitch_cherrymx_hotswap_1u.kicad_mod#L87

See how the broken one has your local path hardcoded?

Even still, many of the footprints still use a different dynamic variable. So I'm not sure if this is the correct fix or whether other parts need changing as well.
